### PR TITLE
Bump Docker image used from 0.0.2 to 0.0.3

### DIFF
--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -3,6 +3,6 @@ version: '3.1'
 
 services:
   vdp-scanner:
-    image: 'cisagov/vdp-scanner:0.0.2'
+    image: 'cisagov/vdp-scanner:0.0.3'
     volumes:
       - ./output:/task/host_mount


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the Docker image used by the `docker-compose.yml` defined in this Ansible role.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will ensure that new deployments are using the latest version available for the [cisagov/vdp-scanner-docker](https://github.com/cisagov/vdp-scanner-docker) image.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automatic tests pass.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
