### PR TITLE
Add the Fedora foo that waits for systemd to initialize before continuing

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,4 +1,32 @@
 ---
+# When installing packages during later steps, the Fedora Docker
+# images we are using (geerlingguy/docker-fedora32-ansible:latest,
+# cisagov/docker-fedora33-ansible:latest, and
+# cisagov/docker-fedora34-ansible:latest) can throw sporadic errors
+# like:
+#
+# No such file or directory: '/var/cache/dnf/metadata_lock.pid'
+#
+# Our fix is to ensure that systemd finishes initializing before
+# continuing on to the converge tasks.  For details see:
+# https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      ansible.builtin.group_by:
+        key: os_{{ ansible_distribution }}
+- name: Wait for systemd to complete initialization (Fedora)
+  hosts: os_Fedora
+  tasks:
+    - name: Wait for systemd to complete initialization # noqa 303
+      ansible.builtin.command: systemctl is-system-running
+      register: systemctl_status
+      until: "'running' in systemctl_status.stdout"
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+
 - name: Import upgrade playbook
   ansible.builtin.import_playbook: upgrade.yml
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds to the `prepare.yml` playbook the `molecule`+Fedora foo that waits for systemd to initialize before continuing.

## 💭 Motivation and context ##

@dav3r had some failed builds due to this golden oldie, so he asked me to apply the old razzle-dazzle.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
